### PR TITLE
fix: linux tf command /recursive parameter should with prefix -recursive

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,8 +1,10 @@
 import * as vscode from "vscode"
 import { tf } from "../tfs/tfExe"
+import * as os from "os"
 
 export async function add(uri: vscode.Uri): Promise<void> {
-  const task = tf(["add", uri.fsPath, "/recursive"])
+  const prefix = os.platform() === "linux" ? "-" : "/" // ’darwin’, ‘freebsd’, ‘linux’, ‘sunos’ , ‘win32’
+  const task = tf(["add", uri.fsPath, `${prefix}recursive`])
 
   vscode.window.setStatusBarMessage("TFS: Adding...", task)
   await task

--- a/src/commands/checkin.ts
+++ b/src/commands/checkin.ts
@@ -1,8 +1,10 @@
 import * as vscode from "vscode"
 import { tf } from "../tfs/tfExe"
+import * as os from "os"
 
 export async function checkin(uri: vscode.Uri): Promise<void> {
-  const task = tf(["checkin", uri.fsPath, "/recursive"])
+  const prefix = os.platform() === "linux" ? "-" : "/"
+  const task = tf(["checkin", uri.fsPath, `${prefix}recursive`])
 
   vscode.window.setStatusBarMessage("TFS: Checking In...", task)
   const { stdout } = await task

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -1,8 +1,10 @@
 import * as vscode from "vscode"
 import { tf } from "../tfs/tfExe"
+import * as os from "os"
 
 export async function checkout(uri: vscode.Uri): Promise<void> {
-  const task = tf(["checkout", uri.fsPath, "/recursive"])
+  const prefix = os.platform() === "linux" ? "-" : "/" // ’darwin’, ‘freebsd’, ‘linux’, ‘sunos’ , ‘win32’
+  const task = tf(["checkout", uri.fsPath, `${prefix}recursive`])
 
   vscode.window.setStatusBarMessage("TFS: Checking...", task)
   await task

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,8 +1,10 @@
 import * as vscode from "vscode"
 import { tf } from "../tfs/tfExe"
+import * as os from "os"
 
 export async function del(uri: vscode.Uri): Promise<void> {
-  const task = tf(["delete", uri.fsPath, "/recursive"])
+  const prefix = os.platform() === "linux" ? "-" : "/" // ’darwin’, ‘freebsd’, ‘linux’, ‘sunos’ , ‘win32’
+  const task = tf(["delete", uri.fsPath, `${prefix}recursive`])
 
   vscode.window.setStatusBarMessage("TFS: Deleting...", task)
   await task

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -1,8 +1,10 @@
 import * as vscode from "vscode"
 import { tf } from "../tfs/tfExe"
+import * as os from "os"
 
 export async function get(uri: vscode.Uri): Promise<void> {
-  const task = tf(["get", uri.fsPath, "/recursive"])
+  const prefix = os.platform() === "linux" ? "-" : "/" // ’darwin’, ‘freebsd’, ‘linux’, ‘sunos’ , ‘win32’
+  const task = tf(["get", uri.fsPath, `${prefix}recursive`])
 
   vscode.window.setStatusBarMessage("TFS: Getting latest version...", task)
   await task

--- a/src/commands/undo.ts
+++ b/src/commands/undo.ts
@@ -1,8 +1,10 @@
 import * as vscode from "vscode"
 import { tf } from "../tfs/tfExe"
+import * as os from "os"
 
 export async function undo(uri: vscode.Uri): Promise<void> {
-  const task = tf(["undo", uri.fsPath, "/recursive"])
+  const prefix = os.platform() === "linux" ? "-" : "/" // ’darwin’, ‘freebsd’, ‘linux’, ‘sunos’ , ‘win32’
+  const task = tf(["undo", uri.fsPath, `${prefix}recursive`])
 
   vscode.window.setStatusBarMessage("TFS: Undoing...", task)
   await task


### PR DESCRIPTION
There is no Visual Studio with Team Foundation Server, but  Cross-platform Command-line Client for Team Foundation Server.

The tfs ... /recursive should be -recursive in Linux. #10 

#  Command-line Client for TFS
[microsoft/team-explorer-everywhere: Team Explorer Everywhere Plugin for Eclipse](https://github.com/microsoft/team-explorer-everywhere?tab=readme-ov-file#what-is-the-command-line-client-for-tfs) has the same functions.

## [Where Can I Get The Command-line Client?](https://github.com/microsoft/team-explorer-everywhere?tab=readme-ov-file#where-can-i-get-the-command-line-client)
Download the TEE-CLC-*.zip file in the [Releases](https://github.com/Microsoft/team-explorer-everywhere/releases) area of this repo.